### PR TITLE
Compose type extractor and regex extractor instead of replacing the first by the second

### DIFF
--- a/slybot/item.py
+++ b/slybot/item.py
@@ -69,8 +69,9 @@ def apply_extractors(descriptor, template_extractors, all_extractors):
             descriptor.attribute_map[field_name] = SlybotFieldDescriptor(field_name, 
                     field_name, field_type_manager.type_processor_class("text"))
         if "regular_expression" in extractor_doc:
-            descriptor.attribute_map[field_name].extractor = \
-                    create_regex_extractor(extractor_doc["regular_expression"])
+            original_extractor = descriptor.attribute_map[field_name].extractor
+            new_extractor = lambda x: create_regex_extractor(extractor_doc["regular_expression"])(original_extractor(x) or '')
+            descriptor.attribute_map[field_name].extractor = new_extractor
         else:
             descriptor.attribute_map[field_name].extractor = \
                     getattr(ExtractorTypes, extractor_doc["builtin_extractor"])

--- a/slybot/tests/test_extractors.py
+++ b/slybot/tests/test_extractors.py
@@ -1,12 +1,94 @@
 from unittest import TestCase
 
+from scrapely.htmlpage import HtmlPage
+from scrapely.extraction import InstanceBasedLearningExtractor
+
 from slybot.utils import create_regex_extractor
 from slybot.fieldtypes import TextFieldTypeProcessor
+from slybot.item import create_slybot_item_descriptor, apply_extractors
+
 
 class ExtractorTest(TestCase):
+
+    annotated = u"""
+<tr data-scrapy-annotate="{&quot;required&quot;: [], &quot;variant&quot;: 0, &quot;annotations&quot;: {&quot;content&quot;: &quot;gender&quot;}}">
+<th class="item-key">Gender</th>
+<td >Male</td></tr>"""
+    target =  u"""
+<tr>
+<th class="item-key">Gender</th>
+<td >Male</td></tr>"""
+
+    template = HtmlPage(url="http://www.test.com/", body=annotated)
+    target = HtmlPage(url="http://www.test.com/", body=target)
+
     def test_regex_extractor(self):
         extractor = create_regex_extractor("(\d+).*(\.\d+)")
         extracted = extractor(u"The price of this product is <div>45</div> </div class='small'>.50</div> pounds")
         self.assertEqual(extracted, u"45.50")
         processor = TextFieldTypeProcessor()
         self.assertEqual(processor.adapt(extracted, None), u"45.50")
+
+    def test_raw_type_w_regex(self):
+        schema = {
+            "id": "test",
+            "properties": [('gender', {
+                    'description': '',
+                    'optional': True,
+                    'type': 'raw',
+                    'vary': False,
+            })],
+        }
+        descriptor = create_slybot_item_descriptor(schema)
+        extractors =  {1: {
+                        "_id": 1,
+                        "field_name": "gender",
+                        "regular_expression": "Gender.*(<td\s*>(?:Male|Female)</td>)"
+        }}
+        apply_extractors(descriptor, [1], extractors)
+
+        ibl_extractor = InstanceBasedLearningExtractor([(self.template, descriptor)])
+        self.assertEqual(ibl_extractor.extract(self.target)[0][0], {u'gender': [u'<td >Male</td>']})
+
+    def test_negative_hit_w_regex(self):
+        schema = {
+            "id": "test",
+            "properties": [('gender', {
+                    'description': '',
+                    'optional': True,
+                    'type': 'number',
+                    'vary': False,
+            })],
+        }
+        descriptor = create_slybot_item_descriptor(schema)
+        extractors =  {1: {
+                        "_id": 1,
+                        "field_name": "gender",
+                        "regular_expression": "Gender\\s+(Male|Female)"
+        }}
+        apply_extractors(descriptor, [1], extractors)
+        
+        ibl_extractor = InstanceBasedLearningExtractor([(self.template, descriptor)])
+        self.assertEqual(ibl_extractor.extract(self.target)[0], None)
+      
+    def test_text_type_w_regex(self):
+        schema = {
+            "id": "test",
+            "properties": [('gender', {
+                    'description': '',
+                    'optional': True,
+                    'type': 'text',
+                    'vary': False,
+            })],
+        }
+        descriptor = create_slybot_item_descriptor(schema)
+        extractors =  {1: {
+                        "_id": 1,
+                        "field_name": "gender",
+                        "regular_expression": "Gender\\s+(Male|Female)"
+        }}
+        apply_extractors(descriptor, [1], extractors)
+        
+        ibl_extractor = InstanceBasedLearningExtractor([(self.template, descriptor)])
+        self.assertEqual(ibl_extractor.extract(self.target)[0][0], {u'gender': [u'Male']})
+


### PR DESCRIPTION
When applying regex extractor, compose type extractor with regex extractors instead of replacing the first with the second, in order to conserve type consistency. Also added tests.
