### PR TITLE
exception fixes in extractors

### DIFF
--- a/slybot/extractors.py
+++ b/slybot/extractors.py
@@ -18,7 +18,7 @@ def create_regex_extractor(pattern):
     def _extractor(txt):
         m = ereg.search(txt)
         if m:
-            return htmlregion("".join(filter(None, m.groups())))
+            return htmlregion(u"".join(filter(None, m.groups() or m.group())))
     
     return _extractor
 
@@ -28,7 +28,7 @@ class PipelineExtractor:
     
     def __call__(self, value):
         for extractor in self.extractors:
-            value = extractor(value or "")
+            value = extractor(value or u"")
         return value
     
 

--- a/slybot/tests/test_extractors.py
+++ b/slybot/tests/test_extractors.py
@@ -138,4 +138,25 @@ class ExtractorTest(TestCase):
         ibl_extractor = InstanceBasedLearningExtractor([(self.template, descriptor)])
         self.assertEqual(ibl_extractor.extract(self.target)[0][0], {u'gender': [u'Male']})
 
+    def test_text_type_w_regex_and_no_groups(self):
+        schema = {
+            "id": "test",
+            "properties": [('gender', {
+                    'description': '',
+                    'optional': True,
+                    'type': 'text',
+                    'vary': False,
+            })],
+        }
+        descriptor = create_slybot_item_descriptor(schema)
+        extractors =  {1: {
+                        "_id": 1,
+                        "field_name": "gender",
+                        "regular_expression": "Gender"
+        }}
+        apply_extractors(descriptor, [1], extractors)
+        
+        ibl_extractor = InstanceBasedLearningExtractor([(self.template, descriptor)])
+        self.assertEqual(ibl_extractor.extract(self.target)[0][0], {u'gender': [u'Gender']})
+
 


### PR DESCRIPTION
fix unicode exceptions when instantiating an htmlregion, and avoid exception when no group is defined in extractor regex. Added tests
