### PR TITLE
Add support for named parameters in generic forms.

### DIFF
--- a/docs/project.rst
+++ b/docs/project.rst
@@ -395,6 +395,12 @@ type : string
   the search form will be posted once per every possible value of the field.
   The field values are extracted from the list of options defined for the field.
 
+name : string : optional
+  If this field is set then it will be used as the option name sent to the server
+  overriding the field name. This can be used to submit values for fields not
+  present in the form (this is useful in some cases like when the data submitted
+  is modified by javascript, i.e in aspx forms).
+
 value: string : optional
   If the field type is "fixed" this value will be used to post the form.
 

--- a/slybot/generic_form.py
+++ b/slybot/generic_form.py
@@ -8,10 +8,14 @@ def _pick_node(doc, selector):
 
 def _get_field_values(form, field_descriptor):
     field_type = field_descriptor['type']
-    select_field = _pick_node(form, field_descriptor)
     if field_type == 'fixed':
-        return [[select_field.name, field_descriptor['value']]]
+        if 'name' in field_descriptor:
+            return [[field_descriptor['name'], field_descriptor['value']]]
+        else:
+            select_field = _pick_node(form, field_descriptor)
+            return [[select_field.name, field_descriptor['value']]]
     elif field_type == 'all':
+        select_field = _pick_node(form, field_descriptor)
         return [[select_field.name, option] for option in select_field.value_options]
 
 def fill_generic_form(url, body, form_descriptor):

--- a/slybot/tests/test_generic_form.py
+++ b/slybot/tests/test_generic_form.py
@@ -54,3 +54,24 @@ class GenericFormTest(TestCase):
                              ([('_in_kw', '3'), ('_udlo', ''), ('_ex_kw', ''), ('_nkw', u'Cars'), ('_ipg', '50'), ('_adv', '1'), ('_salic', '1'), ('_dmd', '1'), ('_fsradio', '&LH_SpecificSeller=1'), ('_udhi', ''), ('_sop', '12'), ('_sasl', '')], 'http://www.ebay.com/sch/i.html', 'GET'),
                              ([('_in_kw', '4'), ('_udlo', ''), ('_ex_kw', ''), ('_nkw', u'Cars'), ('_ipg', '50'), ('_adv', '1'), ('_salic', '1'), ('_dmd', '1'), ('_fsradio', '&LH_SpecificSeller=1'), ('_udhi', ''), ('_sop', '12'), ('_sasl', '')], 'http://www.ebay.com/sch/i.html', 'GET')]
         self.assertEqual(start_requests, expected_requests)
+
+    def test_simple_search_form_with_named_parameter(self):
+        url = 'http://www.ebay.com/sch/ebayadvsearch/?rt=nc'
+        body = open(join(_PATH, "data", "ebay_advanced_search.html")).read()
+        form_descriptor = json.loads("""{
+            "type": "form",
+            "form_url": "http://http://www.ebay.com/sch/ebayadvsearch/?rt=nc",
+            "xpath": "//form[@name='adv_search_from']",
+            "fields": [
+                {
+                  "name": "my_param",
+                  "type": "fixed",
+                  "value": "Cars"
+                }
+            ]
+        }""")
+
+        start_requests = list(fill_generic_form(url, body, form_descriptor))
+        expected_requests = [([('_in_kw', '1'), ('_udlo', ''), ('_ex_kw', ''), ('_nkw', ''), ('_ipg', '50'), ('_adv', '1'), ('_salic', '1'), ('_dmd', '1'), ('_fsradio', '&LH_SpecificSeller=1'), ('_udhi', ''), ('_sop', '12'), (u'my_param', u'Cars'), ('_sasl', '')], 'http://www.ebay.com/sch/i.html', 'GET')]
+        self.assertEqual(start_requests, expected_requests)
+


### PR DESCRIPTION
This is a small change to generic-forms, it allows to define a named parameter with a fixed value, that will be added to the data being posted. This is used to simulate the behavior of some aspx forms which use javascript to append fields to the submitted data.
