### PR TITLE
Add allowed_domains variable to spider definition

### DIFF
--- a/docs/project.rst
+++ b/docs/project.rst
@@ -179,6 +179,7 @@ The Spider object is the top-level object that describes a slybot spider::
 
     {
         "start_urls": list of strings,
+        "allowed_domains": list of strings,
         "links_to_follow": string,
         "follow_patterns": list of strings,
         "exclude_patterns": list of strings,
@@ -191,6 +192,9 @@ Attributes:
 
 start_urls : list of strings
   The list of URLs the spider will start crawling from
+
+allowed_domains : list of strings : optional
+  The list of domains that can be crawled. If set to an empty list it will allow any domain. If this variable is not set then the list of allowed domains is extracted from the start urls.
 
 links_to_follow : string
   Either one of these values:

--- a/slybot/spider.py
+++ b/slybot/spider.py
@@ -58,8 +58,10 @@ class IblSpider(BaseSpider):
 
         self.html_link_extractor = HtmlLinkExtractor()
         self.rss_link_extractor = RssLinkExtractor()
-        self.allowed_domains = self._get_allowed_domains(self._ipages)
-
+        self.allowed_domains = spec.get('allowed_domains',
+                                        self._get_allowed_domains(self._ipages))
+        if not self.allowed_domains:
+            self.allowed_domains = None
         self.build_url_filter(spec)
 
         self.itemcls_info = {}
@@ -201,7 +203,7 @@ class IblSpider(BaseSpider):
         if isinstance(response, HtmlResponse):
             return self.handle_html(response)
         elif "application/rss+xml" in content_type:
-            return self.handle_rss(response) 
+            return self.handle_rss(response)
         else:
             self.log("Ignoring page with content-type=%r: %s" % (content_type, \
                 response.url), level=log.DEBUG)

--- a/slybot/tests/data/Plants/spiders/allowed_domains.json
+++ b/slybot/tests/data/Plants/spiders/allowed_domains.json
@@ -1,0 +1,14 @@
+{
+    "templates": [], 
+    "start_urls": [
+        "http://www.ebay.com/sch/ebayadvsearch/?rt=nc"
+    ], 
+    "allowed_domains": [
+        "www.ebay.com",
+        "www.yahoo.com"
+    ], 
+    "exclude_patterns": [], 
+    "respect_nofollow": true, 
+    "follow_patterns": [], 
+    "links_to_follow": "none"
+}

--- a/slybot/tests/data/Plants/spiders/any_allowed_domains.json
+++ b/slybot/tests/data/Plants/spiders/any_allowed_domains.json
@@ -1,0 +1,12 @@
+{
+    "templates": [], 
+    "start_urls": [
+        "http://www.ebay.com/"
+    ], 
+    "allowed_domains": [],
+    "exclude_patterns": [], 
+    "respect_nofollow": true, 
+    "follow_patterns": [], 
+    "scrapes": "default", 
+    "links_to_follow": "none"
+}

--- a/slybot/tests/data/Plants/spiders/ebay3.json
+++ b/slybot/tests/data/Plants/spiders/ebay3.json
@@ -1,12 +1,12 @@
 {
     "templates": [], 
     "start_urls": [
-        "http://http://www.ebay.com/sch/ebayadvsearch/?rt=nc"
+        "http://www.ebay.com/sch/ebayadvsearch/?rt=nc"
     ], 
     "init_requests": [
         {
             "type": "form",
-            "form_url": "http://http://www.ebay.com/sch/ebayadvsearch/?rt=nc",
+            "form_url": "http://www.ebay.com/sch/ebayadvsearch/?rt=nc",
             "xpath": "//form[@name='adv_search_from']",
             "fields": [
                 {

--- a/slybot/tests/data/Plants/spiders/ebay4.json
+++ b/slybot/tests/data/Plants/spiders/ebay4.json
@@ -1,12 +1,12 @@
 {
     "templates": [], 
     "start_urls": [
-        "http://http://www.ebay.com/sch/ebayadvsearch/?rt=nc"
+        "http://www.ebay.com/sch/ebayadvsearch/?rt=nc"
     ], 
     "init_requests": [
         {
             "type": "form",
-            "form_url": "http://http://www.ebay.com/sch/ebayadvsearch/?rt=nc",
+            "form_url": "http://www.ebay.com/sch/ebayadvsearch/?rt=nc",
             "xpath": "//form[@name='adv_search_from']",
             "fields": [
                 {

--- a/slybot/tests/test_spider.py
+++ b/slybot/tests/test_spider.py
@@ -16,7 +16,7 @@ class SpiderTest(TestCase):
     def test_list(self):
         self.assertEqual(set(self.smanager.list()), set(["seedsofchange", "seedsofchange2",
                 "seedsofchange.com", "pinterest.com", "ebay", "ebay2", "ebay3", "ebay4", "cargurus",
-                "networkhealth.com"]))
+                "networkhealth.com", "allowed_domains", "any_allowed_domains"]))
 
     def test_spider_with_link_template(self):
         name = "seedsofchange"
@@ -165,12 +165,30 @@ class SpiderTest(TestCase):
         spider = self.smanager.create(name, **args)
         generic_form_request = list(spider.start_requests())[0]
 
-        response = HtmlResponse(url="http://http://www.ebay.com/sch/ebayadvsearch/?rt=nc", body=open(join(_PATH, "data", "ebay_advanced_search.html")).read())
+        response = HtmlResponse(url="http://www.ebay.com/sch/ebayadvsearch/?rt=nc", body=open(join(_PATH, "data", "ebay_advanced_search.html")).read())
         response.request = generic_form_request
         request_list = [request_to_dict(req, spider)
                              for req in generic_form_request.callback(response)]
-        expected = [{'body': '', '_encoding': 'utf-8', 'cookies': {}, 'meta': {}, 'headers': {}, 'url': u'http://www.ebay.com/sch/i.html?_adv=1&_ex_kw=&_ftrv=1&_ftrt=901&_sabdlo=&_sabdhi=&_sop=12&_samihi=&_ipg=50&_salic=1&_sasl=&_udlo=&_okw=&_fsradio=%26LH_SpecificSeller%3D1&_udhi=&_in_kw=1&_nkw=Cars&_sacat=0&_oexkw=&_dmd=1&_saslop=1&_samilow=', 'dont_filter': True, 'priority': 0, 'callback': 'after_form_page', 'method': 'GET', 'errback': None}, {'body': '', '_encoding': 'utf-8', 'cookies': {}, 'meta': {}, 'headers': {}, 'url': u'http://www.ebay.com/sch/i.html?_adv=1&_ex_kw=&_ftrv=1&_ftrt=901&_sabdlo=&_sabdhi=&_sop=12&_samihi=&_ipg=50&_salic=1&_sasl=&_udlo=&_okw=&_fsradio=%26LH_SpecificSeller%3D1&_udhi=&_in_kw=2&_nkw=Cars&_sacat=0&_oexkw=&_dmd=1&_saslop=1&_samilow=', 'dont_filter': True, 'priority': 0, 'callback': 'after_form_page', 'method': 'GET', 'errback': None}, {'body': '', '_encoding': 'utf-8', 'cookies': {}, 'meta': {}, 'headers': {}, 'url': u'http://www.ebay.com/sch/i.html?_adv=1&_ex_kw=&_ftrv=1&_ftrt=901&_sabdlo=&_sabdhi=&_sop=12&_samihi=&_ipg=50&_salic=1&_sasl=&_udlo=&_okw=&_fsradio=%26LH_SpecificSeller%3D1&_udhi=&_in_kw=3&_nkw=Cars&_sacat=0&_oexkw=&_dmd=1&_saslop=1&_samilow=', 'dont_filter': True, 'priority': 0, 'callback': 'after_form_page', 'method': 'GET', 'errback': None}, {'body': '', '_encoding': 'utf-8', 'cookies': {}, 'meta': {}, 'headers': {}, 'url': u'http://www.ebay.com/sch/i.html?_adv=1&_ex_kw=&_ftrv=1&_ftrt=901&_sabdlo=&_sabdhi=&_sop=12&_samihi=&_ipg=50&_salic=1&_sasl=&_udlo=&_okw=&_fsradio=%26LH_SpecificSeller%3D1&_udhi=&_in_kw=4&_nkw=Cars&_sacat=0&_oexkw=&_dmd=1&_saslop=1&_samilow=', 'dont_filter': True, 'priority': 0, 'callback': 'after_form_page', 'method': 'GET', 'errback': None}, {'body': '', '_encoding': 'utf-8', 'cookies': {}, 'meta': {}, 'headers': {}, 'url': u'http://http://www.ebay.com/sch/ebayadvsearch/?rt=nc', 'dont_filter': True, 'priority': 0, 'callback': 'parse', 'method': 'GET', 'errback': None}]
+        expected = [{'body': '', '_encoding': 'utf-8', 'cookies': {}, 'meta': {}, 'headers': {}, 'url': u'http://www.ebay.com/sch/i.html?_adv=1&_ex_kw=&_ftrv=1&_ftrt=901&_sabdlo=&_sabdhi=&_sop=12&_samihi=&_ipg=50&_salic=1&_sasl=&_udlo=&_okw=&_fsradio=%26LH_SpecificSeller%3D1&_udhi=&_in_kw=1&_nkw=Cars&_sacat=0&_oexkw=&_dmd=1&_saslop=1&_samilow=', 'dont_filter': True, 'priority': 0, 'callback': 'after_form_page', 'method': 'GET', 'errback': None}, {'body': '', '_encoding': 'utf-8', 'cookies': {}, 'meta': {}, 'headers': {}, 'url': u'http://www.ebay.com/sch/i.html?_adv=1&_ex_kw=&_ftrv=1&_ftrt=901&_sabdlo=&_sabdhi=&_sop=12&_samihi=&_ipg=50&_salic=1&_sasl=&_udlo=&_okw=&_fsradio=%26LH_SpecificSeller%3D1&_udhi=&_in_kw=2&_nkw=Cars&_sacat=0&_oexkw=&_dmd=1&_saslop=1&_samilow=', 'dont_filter': True, 'priority': 0, 'callback': 'after_form_page', 'method': 'GET', 'errback': None}, {'body': '', '_encoding': 'utf-8', 'cookies': {}, 'meta': {}, 'headers': {}, 'url': u'http://www.ebay.com/sch/i.html?_adv=1&_ex_kw=&_ftrv=1&_ftrt=901&_sabdlo=&_sabdhi=&_sop=12&_samihi=&_ipg=50&_salic=1&_sasl=&_udlo=&_okw=&_fsradio=%26LH_SpecificSeller%3D1&_udhi=&_in_kw=3&_nkw=Cars&_sacat=0&_oexkw=&_dmd=1&_saslop=1&_samilow=', 'dont_filter': True, 'priority': 0, 'callback': 'after_form_page', 'method': 'GET', 'errback': None}, {'body': '', '_encoding': 'utf-8', 'cookies': {}, 'meta': {}, 'headers': {}, 'url': u'http://www.ebay.com/sch/i.html?_adv=1&_ex_kw=&_ftrv=1&_ftrt=901&_sabdlo=&_sabdhi=&_sop=12&_samihi=&_ipg=50&_salic=1&_sasl=&_udlo=&_okw=&_fsradio=%26LH_SpecificSeller%3D1&_udhi=&_in_kw=4&_nkw=Cars&_sacat=0&_oexkw=&_dmd=1&_saslop=1&_samilow=', 'dont_filter': True, 'priority': 0, 'callback': 'after_form_page', 'method': 'GET', 'errback': None}, {'body': '', '_encoding': 'utf-8', 'cookies': {}, 'meta': {}, 'headers': {}, 'url': u'http://www.ebay.com/sch/ebayadvsearch/?rt=nc', 'dont_filter': True, 'priority': 0, 'callback': 'parse', 'method': 'GET', 'errback': None}]
         self.assertEqual(request_list, expected)
+
+    def test_allowed_domains(self):
+        name = "allowed_domains"
+        spider = self.smanager.create(name)
+        expected = ['www.ebay.com', 'www.yahoo.com']
+        self.assertEqual(spider.allowed_domains, expected)
+
+    def test_allowed_domains_all(self):
+        name = "any_allowed_domains"
+        spider = self.smanager.create(name)
+        expected = None
+        self.assertEqual(spider.allowed_domains, expected)
+
+    def test_allowed_domains_previous_behavior(self):
+        name = "cargurus"
+        spider = self.smanager.create(name)
+        expected = ['www.cargurus.com']
+        self.assertEqual(spider.allowed_domains, expected)
 
     def test_links_from_rss(self):
         body = open(join(_PATH, "data", "rss_sample.xml")).read()

--- a/slybot/validation/schemas.json
+++ b/slybot/validation/schemas.json
@@ -51,6 +51,7 @@
             "follow_patterns": {"type": "array", "items": {"type": "string", "format": "regex"}},
             "exclude_patterns": {"type": "array", "items": {"type": "string", "format": "regex"}},
             "respect_nofollow": {"type": "boolean", "required": true},
+            "allowed_domains": {"type": "array", "items": {"type": "string"}},
             "templates": {"type": "array", "items": {"$ref": "template"}, "required": true},
             "init_requests": {"type": "array", "items": {"$ref": "request"}}
         }


### PR DESCRIPTION
The allowed_domains settings allow us to control the domains filtered by the OffsiteMiddleware. If not then it does the previous behavior (extract allowed_domains from start_urls)
