### PR TITLE
Show error details when failing to parse project json file

### DIFF
--- a/slybot/utils.py
+++ b/slybot/utils.py
@@ -26,6 +26,6 @@ def open_project_from_dir(project_dir):
             with open(os.path.join(project_dir, "spiders", fname)) as f:
                 try:
                     specs["spiders"][spider_name] = json.load(f)
-                except ValueError:
-                    raise ValueError("Error parsing spider (invalid JSON): %s" % fname)
+                except ValueError, e:
+                    raise ValueError("Error parsing spider (invalid JSON): %s: %s" % (fname, e))
     return specs


### PR DESCRIPTION
Small change to display the error details when the project json is malformed. Without the patch the error message looks like this:

`ValueError: Error parsing spider (invalid JSON): project.json`

With the patch looks like this:

`ValueError: Error parsing spider (invalid JSON): project.json: Expecting object: line 9 column 5 (char 964)`
