### PR TITLE
Update index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ Installation
 
 To install the last development version::
 
-    pip install pip install git+https://github.com/scrapy/slybot.git
+    pip install git+https://github.com/scrapy/slybot.git
 
 To install the last stable version::
 


### PR DESCRIPTION
Minor typo where there was two "pip install" in the dev version installation command line. 

From this: 
    pip install pip install git+https://github.com/scrapy/slybot.git

To this:
    pip install git+https://github.com/scrapy/slybot.git
