### PR TITLE
allow to override some spider specs using spider arguments

### DIFF
--- a/slybot/spider.py
+++ b/slybot/spider.py
@@ -1,6 +1,7 @@
 import itertools
 import operator
 import re
+from copy import deepcopy
 
 from scrapy import log
 from scrapy.spider import BaseSpider
@@ -36,6 +37,11 @@ class IblSpider(BaseSpider):
 
     def __init__(self, name, spec, item_schemas, all_extractors, **kw):
         super(IblSpider, self).__init__(name, **kw)
+        spec = deepcopy(spec)
+        for key, val in kw.items():
+            if isinstance(val, basestring) and key in ['start_urls', 'exclude_patterns', 'follow_patterns', 'allowed_domains']:
+                val = val.splitlines()
+            spec[key] = val
 
         self._item_template_pages = sorted((
             [t['scrapes'], dict_to_page(t, 'annotated_body'),
@@ -88,9 +94,7 @@ class IblSpider(BaseSpider):
             self.allowed_domains = None
 
     def _process_start_urls(self, spec):
-        self.start_urls = self.start_urls or spec.get('start_urls')
-        if isinstance(self.start_urls, basestring):
-            self.start_urls = self.start_urls.splitlines()
+        self.start_urls = spec.get('start_urls')
         for url in self.start_urls:
             self._start_requests.append(Request(url, callback=self.parse, dont_filter=True))
 

--- a/slybot/tests/data/SampleProject/spiders/example3.com.json
+++ b/slybot/tests/data/SampleProject/spiders/example3.com.json
@@ -1,0 +1,8 @@
+{
+    "templates": [],
+    "start_urls": ["http://www.example.com/index.html"],
+    "exclude_patterns": [], 
+    "follow_patterns": [], 
+    "links_to_follow": "patterns", 
+    "respect_nofollow": true
+}

--- a/slybot/tests/test_spider.py
+++ b/slybot/tests/test_spider.py
@@ -16,7 +16,8 @@ class SpiderTest(TestCase):
     def test_list(self):
         self.assertEqual(set(self.smanager.list()), set(["seedsofchange", "seedsofchange2",
                 "seedsofchange.com", "pinterest.com", "ebay", "ebay2", "ebay3", "ebay4", "cargurus",
-                "networkhealth.com", "allowed_domains", "any_allowed_domains", "example.com", "example2.com"]))
+                "networkhealth.com", "allowed_domains", "any_allowed_domains", "example.com", "example2.com",
+                "example3.com"]))
 
     def test_spider_with_link_template(self):
         name = "seedsofchange"
@@ -305,3 +306,21 @@ Product B,http://www.example.com/path2,B"""
         name = "example2.com"
         spider = self.smanager.create(name)
         self.assertEqual(spider.allowed_domains, ['www.example.com'])
+
+    def test_override_start_urls(self):
+        name = "example2.com"
+        spider = self.smanager.create(name, start_urls=['http://www.example.com/override.html'])
+        start_requests = list(spider.start_requests())
+        self.assertEqual(start_requests[1].url, 'http://www.example.com/override.html')
+
+    def test_links_to_follow(self):
+
+        html = "<html><body><a href='http://www.example.com/link.html'>Link</a></body></html>"
+        response = HtmlResponse(url='http://www.example.com/index.html', body=html)
+
+        name = "example3.com"
+        spider = self.smanager.create(name, links_to_follow='none')
+        start_requests = list(spider.start_requests())
+
+        requests = list(start_requests[0].callback(response))
+        self.assertEqual(len(requests), 0)


### PR DESCRIPTION
It is very common to need to hit only one page to be reescraped, without starting a complete crawl, and without editing the spider, which is needed for complete crawls.

A combination of passing arguments start_urls and links_to_follow will resolve this.
